### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/araujofrancisco/diggeo/security/code-scanning/1](https://github.com/araujofrancisco/diggeo/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves building and testing code, it likely only needs read access to the repository contents. The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
